### PR TITLE
Fix Category Archive Page

### DIFF
--- a/wp-content/themes/benmiles-wp/archive.php
+++ b/wp-content/themes/benmiles-wp/archive.php
@@ -13,8 +13,9 @@ if ( is_tag() ) {
 if ( is_category() ) {
 	$meta_type = 'Category';
 	$meta_key = get_category( get_query_var( 'cat' ) );
+	// var_dump($meta_key);
 	$meta_description = '<p>' . $meta_key->description . '</p>';
-	$category = $meta_key->name;
+	$category = $meta_key->slug;
 }
 
 get_header(null, ['bodyClass' => 'page-archive']);


### PR DESCRIPTION
Decided to use slug instead of name for Categories on the Archive Page as well, even though either seems to work, even for Categories with multiple words.